### PR TITLE
Added portDefinitions for app config

### DIFF
--- a/marathon_app.go
+++ b/marathon_app.go
@@ -18,6 +18,10 @@ import (
         8080,
         9000
     ],
+    "portDefinitions": [
+        { "port": 8080, "protocol": "tcp", "name": "http", labels: { "VIP_0": "10.0.0.1:80" } },
+        { "port": 9000, "protocol": "tcp", "name": "admin" }
+    ],
     "requirePorts": false,
     "instances": 3,
     "executor": "",
@@ -164,8 +168,13 @@ type MarathonApp struct {
 	MaxLaunchDelaySeconds int               `yaml:"maxLaunchDelaySeconds" json:"maxLaunchDelaySeconds,omitempty"`
 	Memory                int               `yaml:"mem" json:"mem,omitempty"`
 	Ports                 []int             `yaml:"ports" json:"ports,omitempty"`
-	RequirePorts          bool              `yaml:"requirePorts,omitempty" json:"requirePorts"`
-	UpgradeStrategy       struct {
+	PortDefinitions       []struct {
+		Port     string `yaml:"port" json:"port,omitempty"`
+		Protocol string `yaml:"protocol" json:"protocol,omitempty"`
+		Name     string `yaml:"name" json:"name,omitempty"`
+	} `yaml:"portDefinitions" json:"portDefinitions,omitempty"`
+	RequirePorts    bool `yaml:"requirePorts,omitempty" json:"requirePorts"`
+	UpgradeStrategy struct {
 		MaximumOverCapacity   *float64 `yaml:"maximumOverCapacity" json:"maximumOverCapacity,omitempty"`
 		MinimumHealthCapacity *float64 `yaml:"minimumHealthCapacity" json:"minimumHealthCapacity,omitempty"`
 	} `yaml:"upgradeStrategy" json:"upgradeStrategy,omitempty"`


### PR DESCRIPTION
Marathon HTTP API has a portDefinitions array as part of the create application configuration.

https://mesosphere.github.io/marathon/docs/rest-api.html#portsdefinitions-array-of-objects

Adding support allows greater visibility for services running in HOST networking mode when usually Marathon is unaware of the port assignments.