### PR TITLE
Port as int not string

### DIFF
--- a/marathon_app.go
+++ b/marathon_app.go
@@ -169,7 +169,7 @@ type MarathonApp struct {
 	Memory                int               `yaml:"mem" json:"mem,omitempty"`
 	Ports                 []int             `yaml:"ports" json:"ports,omitempty"`
 	PortDefinitions       []struct {
-		Port     string `yaml:"port" json:"port,omitempty"`
+		Port     int    `yaml:"port" json:"port,omitempty"`
 		Protocol string `yaml:"protocol" json:"protocol,omitempty"`
 		Name     string `yaml:"name" json:"name,omitempty"`
 	} `yaml:"portDefinitions" json:"portDefinitions,omitempty"`


### PR DESCRIPTION
Fix portDefinitions port as an int, not a string. Marathon HTTP API does not accept type string and returns HTTP 400.