### PR TITLE
Add two environment variables to all configurations

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ container:
 instances: 1
 env: 
   DOCKER_API_VERSION: "1.21"
+  VAULT_SKIP_VERIFY: "true"
+  VAULT_CA_PATH: ""
 `
 
 var (


### PR DESCRIPTION
This *should* add two fixed environment variables to any jobs deployed using Marathon:

> VAULT_CAPATH=
> VAULT_SKIP_VERIFY=true

Example JSON generated:

> {

>   "container": {
>     "type": "DOCKER",
>     "docker": {
>       "image": "greyrhino/rexray:0.0.2",
>       "network": "BRIDGE",
>       "privileged": true,
>       "parameters": [
>         {
>           "key": "ipc",
>           "value": "host"
>         },
>         {
>           "key": "security-opt",
>           "value": "label:disable"
>         }
>       ]
>     },
>     "volumes": [
>       {
>         "containerPath": "/run/docker",
>         "hostPath": "/run/docker",
>         "mode": "RW"
>       },
>       {
>         "containerPath": "/dev",
>         "hostPath": "/dev",
>         "mode": "RW"
>       },
>       {
>         "containerPath": "/dev/pts",
>         "hostPath": "/dev/pts",
>         "mode": "RO"
>       },
>       {
>         "containerPath": "/var/lib/rexray",
>         "hostPath": "/var/lib/rexray",
>         "mode": "RW"
>       },
>       {
>         "containerPath": "/etc/fstab",
>         "hostPath": "/etc/fstab",
>         "mode": "RW"
>       },
>       {
>         "containerPath": "/host",
>         "hostPath": "/",
>         "mode": "RO"
>       },
>       {
>         "containerPath": "/usr/local/libexec",
>         "hostPath": "/usr/local/libexec",
>         "mode": "RW"
>       }
>     ]
>   },
>   "cpus": 0.1,
>   "env": {
>     "DOCKER_API_VERSION": "1.21",
>     "JAVA_OPTS": "-Xmx1024m -Xms1024m -Djavax.net.ssl.keyStore=/mnt/mesos/sandbox/named?name=atgtest2back4.jks -Djavax.net.ssl.keyStorePassword={{keystore_password}} -XX:MaxPermSize=512m -Denvironment={{environment}} -Ddatanucleus.schema.autoCreateTables={{auto_create_tables}} -DnutmegCache.memcachedServer={{memcache_server}} -DnutmegCSCache.memcachedServer={{memcache_server}} -DdataNucleusPMF.datanucleus.cache.level2.type={{datanucleus_cache_type}} -DwebsiteDataSource.jdbcUrl={{db_nutmeg_url}} -DwebsiteDataSource.username={{db_nutmeg_username}} -DwebsiteDataSource.password={{db_nutmeg_password}} -DbabelDataSource.jdbcUrl={{db_babelsys_url}} -DbabelDataSource.username={{db_babelsys_username}} -DbabelDataSource.password={{db_babelsys_password}} -DdataNucleusDataSource.jdbcUrl={{db_nutmeg01_url}} -DdataNucleusDataSource.username={{db_nutmeg01_username}} -DdataNucleusDataSource.password={{db_nutmeg01_password}}  -Dcom.sun.xml.ws.transport.http.client.HttpTransportPipe.dump={{java_debug}} -Dcom.sun.xml.internal.ws.transport.http.client.HttpTransportPipe.dump={{java_debug}} -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump={{java_debug}} -Dcom.sun.xml.internal.ws.transport.http.HttpAdapter.dump={{java_debug}}",
>     "VAULT_CA_PATH": "",
>     "VAULT_SKIP_VERIFY": "true"
>   },
>   "healthChecks": [
>     {
>       "gracePeriodSeconds": 1500,
>       "intervalSeconds": 15,
>       "maxConsecutiveFailures": 10,
>       "path": "/api/health",
>       "protocol": "HTTP",
>       "timeoutSeconds": 5
>     }
>   ],
>   "id": "/rexray",
>   "instances": 1,
>   "labels": {
>     "environment": "{{environment}}",
>     "tags": "monitor"
>   },
>   "mem": 128
> }
> 