### PR TITLE
CAPATH needs a value - and does not need a typo

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ instances: 1
 env: 
   DOCKER_API_VERSION: "1.21"
   VAULT_SKIP_VERIFY: "true"
-  VAULT_CA_PATH: ""
+  VAULT_CA_PATH: "/tmp"
 `
 
 var (


### PR DESCRIPTION
Typo on CAPATH - but, more importantly, it's need a valid path as it's value.