### PR TITLE
EE-288 Remove vault env vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,8 +20,6 @@ container:
 instances: 1
 env: 
   DOCKER_API_VERSION: "1.21"
-  VAULT_SKIP_VERIFY: "true"
-  VAULT_CA_PATH: "/tmp"
 `
 
 var (


### PR DESCRIPTION
These variables are no longer required and it has been agreed with the TLs that this can be removed.